### PR TITLE
Added fallback if stack or dynamicObjects array is null

### DIFF
--- a/iso/MapLayer.hx
+++ b/iso/MapLayer.hx
@@ -46,6 +46,7 @@ class MapLayer
 	{
 		//Create new iso tile and set a reference to the FlxSprite inside it
 		var stack = stacks[r][c];
+		if (stack == null) return;
 		obj.setPosition(stack.root.x, stack.root.y);
 		
 		var tile = new IsoTile(0, obj.x, obj.y, c, r, obj);
@@ -107,7 +108,7 @@ class MapLayer
 	
 	public function update(elapsed:Float)
 	{
-		if (map == null) return;
+		if (map == null || dynamicObjects == null) return;
 		
 		for (i in 0...dynamicObjects.length) {
 			


### PR DESCRIPTION
This caused app to crash on mac when loading TiledState. It seems that one of the dynamic objects had index larger than the stack array size. actually the index was 29 and size was also 29.
