### PR TITLE
Fixed keyboard for mac target

### DIFF
--- a/sample/Project.xml
+++ b/sample/Project.xml
@@ -74,7 +74,7 @@
 	<!--<haxedef name="FLX_NO_FOCUS_LOST_SCREEN" />-->
 
 	<!--Disable the Flixel core debugger. Automatically gets set whenever you compile in release mode!-->
-	<!--<haxedef name="FLX_NO_DEBUG" unless="debug" />-->
+	<haxedef name="FLX_NO_DEBUG" unless="debug" />
 
 	<!--Enable this for Nape release builds for a serious peformance improvement-->
 	<haxedef name="NAPE_RELEASE_BUILD" unless="debug" />


### PR DESCRIPTION
For some reason keyboard was disabled when this line was commented out.
